### PR TITLE
Allow for stdout to return the data in chunks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ var Exec = module.exports = exports = function( args, callback) {
         var stderr = null;
 
         CMD.stdout.on('data', function (data) {
-            stdout.push( data.toString() );
+            stdout = stdout.concat( data.toString().split('\r\n') );
         });
 
         CMD.stderr.on('data', function (data) {


### PR DESCRIPTION
When I ran any ps-node command on windows it was failing with a `undefined is not a function` because output from the command list empty.

Tracked it down to the fact that the data piped in from wmic command is not guaranteed to come in line by line, but the exit function that finds the `beginRow` expects each line to be on its own. This fix splits the data as it comes in to fix this bug.