### PR TITLE
grep option , to search over the full command line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,10 @@ exports.lookup = function(query, callback) {
     }
 
 
+    if( query.grep ){
+        filter[ 'grep' ] = new RegExp( query.grep, 'i' );
+    }
+
     if( query.command ){
         filter[ 'command' ] = new RegExp( query.command, 'i' );
     }
@@ -231,6 +235,7 @@ function formatOutput( data ){
             }
 
             formatedData.push( {
+                grep: cmd,
                 pid: pid,
                 command: command,
                 arguments: args,


### PR DESCRIPTION
Hi , I would like to add this feature to master if you agree, or discuss a better way to achieve the same. This feature will give us the ability to use a single regular expression to search over each line command, without the need of using two separated regular expressions, for command and arguments.

We were using this approach which is similar to a Unix grep.

What do you think ? At this moment we are maintaining a separated fork. It would be great if we can merge it with yours.

If you want , you can see how we are using this in our project [here](https://github.com/interactar/theeye-agent/blob/demo/core/worker/process/index.js).
I will really appreciate your help. Thanks.
