### PR TITLE
Added option to kill process with SIGKILL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,11 +170,24 @@ exports.lookup = function (query, callback) {
 /**
  * Kill process
  * @param pid
+ * @param opts
  * @param next
  */
 
-exports.kill = function (pid, next) {
+exports.kill = function( pid, opts, next ){
+  //opts are optional
+  if(arguments.length == 2 && typeof opts == 'function'){
+    next = opts;
+    opts = {};
+  }
+
   var killCommand = IS_WIN ? 'taskkill ' : 'kill ';
+
+  //For Unix/Mac add the signal to command if provided
+  if(!IS_WIN && opts && opts.signal){
+    killCommand += '-' + opts.signal + ' ';
+  }
+  
   var command = killCommand + ( IS_WIN ? '/F /PID ' + pid : pid );
   ChildProcess.exec(command, function (err, stdout, stderr) {
     if (typeof next !== 'function') return;

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,24 @@ ps.kill( '12345', function( err ) {
 });
 ```
 
+Method `kill` also supports a `signal` option to be passed. This **only** works on Linux/Mac. For a list of all available signals on your system type `kill -l` in your console.
+
+```javascript
+var ps = require('ps-node');
+
+//Pass signal 9 for killing the process witout allowing it to clean up
+ps.kill( '12345', { signal: 9 }, function( err ) {
+    if (err) {
+        throw new Error( err );
+    }
+    else {
+        console.log( 'Process %s has been killed without a clean-up!', pid );
+    }
+});
+```
+
+
+
 You can also pass arguments to `lookup` with `psargs` as arguments for `ps` command（Note that `psargs` is not available in windows):
 
 ```javascript

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,28 @@ describe('test', function () {
       });
     });
 
+    it('should force kill when opts.signal is 9', function (done) {
+      startProcess();
+
+      PS.kill(pid, {signal: 9}, function (err) {
+        assert.equal(err, null);
+        PS.lookup({pid: String(pid)}, function (err, list) {
+          assert.equal(list.length, 0);
+          done();
+        });
+      });
+    });
+
+    it('should throw error when opts.signal is invalid', function (done) {
+      startProcess();
+      PS.kill(pid, {signal: 'INVALID'}, function (err) {
+        assert.notEqual(err, null);
+        PS.kill(pid, function(){
+            done();
+        });
+      });
+    });
+
     it('should not throw an exception if the callback is undefined', function (done) {
       assert.doesNotThrow(function () {
         PS.kill(pid);


### PR DESCRIPTION
Hi, 

In one of my projects i had the need to kill a process with `SIGKILL`. I've added an optional `opts` parameter to the kill function, that allows you to do that if you pass `sigkill: true`. This currently only does it for Unix, as I've noticed that for Windows you already add the `/F` for force killing it.

I've add a test case, and updated documentation.