### PR TITLE
refactor the implementation of kill(), use nodejs build-in process.ki…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,45 +187,41 @@ exports.lookup = function (query, callback) {
 /**
  * Kill process
  * @param pid
- * @param opts
+ * @param {Object|String} signal
+ * @param {String} signal.signal
  * @param next
  */
 
-exports.kill = function( pid, opts, next ){
+exports.kill = function( pid, signal, next ){
   //opts are optional
-  if(arguments.length == 2 && typeof opts == 'function'){
-    next = opts;
-    opts = {};
+  if(arguments.length == 2 && typeof signal == 'function'){
+    next = signal;
+    signal = undefined;
   }
 
-  var killCommand = IS_WIN ? 'taskkill ' : 'kill ';
-
-  //For Unix/Mac add the signal to command if provided
-  if(!IS_WIN && opts && opts.signal){
-    killCommand += '-' + opts.signal + ' ';
+  if (typeof signal === 'object') {
+    signal = signal.signal;
   }
 
-  var command = killCommand + ( IS_WIN ? '/F /PID ' + pid : pid );
-  ChildProcess.exec(command, function (err, stdout, stderr) {
-    if (typeof next !== 'function') return;
-    if ((err || stderr)) {
-      next(err || stderr.toString());
-    }
-    else {
-      stdout = stdout.toString();
+  try {
+    process.kill(pid, signal);
+  } catch(e) {
+    return next && next(e);
+  }
 
-      // on windows, you can still get the killed process if you look it up immediately after you killed it
-      // so wait for an extra 200ms
-      if (IS_WIN) {
-        setTimeout(function () {
-          next(null, stdout);
-        }, 200);
-      }
-      else {
-        next(null, stdout);
-      }
-    }
-  });
+  function checkKilled(finishCallback) {
+    exports.lookup({ pid: pid }, function(err, list) {
+        if (err) {
+          finishCallback && finishCallback(err);
+        } else if(list.length > 0) {
+          checkKilled(finishCallback);
+        } else {
+          finishCallback && finishCallback();
+        }
+    });
+  }
+
+  checkKilled(next);
 };
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -90,13 +90,13 @@ ps.kill( '12345', function( err ) {
 });
 ```
 
-Method `kill` also supports a `signal` option to be passed. This **only** works on Linux/Mac. For a list of all available signals on your system type `kill -l` in your console.
+Method `kill` also supports a `signal` option to be passed. It's only a wrapper of `process.kill()` with checking of that killing is finished after the method is called.
 
 ```javascript
 var ps = require('ps-node');
 
-//Pass signal 9 for killing the process witout allowing it to clean up
-ps.kill( '12345', { signal: 9 }, function( err ) {
+// Pass signal SIGKILL for killing the process without allowing it to clean up
+ps.kill( '12345', 'SIGKILL', function( err ) {
     if (err) {
         throw new Error( err );
     }
@@ -106,6 +106,14 @@ ps.kill( '12345', { signal: 9 }, function( err ) {
 });
 ```
 
+To be compatible with prior versions, you can use object as the second parameter:
+
+```js
+ps.kill( '12345', { signal: 'SIGKILL' }, function(){});
+
+```
+
+Notice that the nodejs build-in `process.kill()` does not accept number as the signal, you will have to use string format.
 
 
 You can also pass arguments to `lookup` with `psargs` as arguments for `ps` command（Note that `psargs` is not available in windows):

--- a/test/test.js
+++ b/test/test.js
@@ -117,8 +117,8 @@ describe('test', function () {
     });
 
     if (!IS_WIN) {
-      it('should force kill when opts.signal is 9', function (done) {
-        PS.kill(pid, {signal: 9}, function (err) {
+      it('should force kill when opts.signal is SIGKILL', function (done) {
+        PS.kill(pid, {signal: 'SIGKILL'}, function (err) {
           assert.equal(err, null);
           PS.lookup({pid: String(pid)}, function (err, list) {
             assert.equal(list.length, 0);


### PR DESCRIPTION
# What

according to https://github.com/neekey/ps/issues/41, refactor `kill()`, as a wrapper of built-in `process.kill()`