### PR TITLE
updated to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2017-03-26](https://github.com/neekey/ps/pull/35)
+- publish 0.1.5
+- Add parent process ID support for windows
+- use `spawn` to replace `exec` for Linux/Unix system
+- add appVeyor integration
+- use Travis for npm publishing
+- refactor the implementation of `kill()`, now just a wrapper of built-in `process.kill()`
+
 ## 2016-06-23
 - Publish 0.1.2
 - change `command` and `argument` matching to case insensitive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2017-04-21](https://github.com/neekey/ps/pull/48)
+- publish 0.1.6
+- use `lx` as default options for `ps` command
+- remove debugging console log for `kill()`
+- add timeout for `kill()`, default to 30s
+
 ## [2017-03-26](https://github.com/neekey/ps/pull/35)
 - publish 0.1.5
 - Add parent process ID support for windows

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,7 @@ exports.lookup = function (query, callback) {
  * @param pid
  * @param {Object|String} signal
  * @param {String} signal.signal
+ * @param {number} signal.timeout
  * @param next
  */
 
@@ -199,6 +200,8 @@ exports.kill = function( pid, signal, next ){
     next = signal;
     signal = undefined;
   }
+
+  var checkTimeoutSeconds = (signal && signal.timeout) || 30;
 
   if (typeof signal === 'object') {
     signal = signal.signal;
@@ -211,27 +214,37 @@ exports.kill = function( pid, signal, next ){
   }
 
   var checkConfident = 0;
+  var checkTimeoutTimer = null;
+  var checkIsTimeout = false;
 
   function checkKilled(finishCallback) {
-    console.log('check kill success', pid, 'confident', checkConfident);
     exports.lookup({ pid: pid }, function(err, list) {
-      console.log('check kill success result:', (list || []).length);
+      if (checkIsTimeout) return;
+
       if (err) {
-          finishCallback && finishCallback(err);
-        } else if(list.length > 0) {
-          checkKilled(finishCallback);
+        clearTimeout(checkTimeoutTimer);
+        finishCallback && finishCallback(err);
+      } else if(list.length > 0) {
+        checkConfident = (checkConfident - 1) || 0;
+        checkKilled(finishCallback);
+      } else {
+        checkConfident++;
+        if (checkConfident === 5) {
+          clearTimeout(checkTimeoutTimer);
+          finishCallback && finishCallback();
         } else {
-          checkConfident++;
-          if (checkConfident === 5) {
-            finishCallback && finishCallback();
-          } else {
-            checkKilled(finishCallback);
-          }
+          checkKilled(finishCallback);
         }
+      }
     });
   }
 
   next && checkKilled(next);
+
+  checkTimeoutTimer = next && setTimeout(function() {
+    checkIsTimeout = true;
+    next(new Error('Kill process timeout'));
+  }, checkTimeoutSeconds * 1000);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,7 @@ var Exec = module.exports = exports = function (args, callback) {
  * @param {String|String[]} query.pid
  * @param {String} query.command RegExp String
  * @param {String} query.arguments RegExp String
+ * @param {String|array} query.psargs
  * @param {Function} callback
  * @param {Object=null} callback.err
  * @param {Object[]} callback.processList
@@ -115,9 +116,9 @@ var Exec = module.exports = exports = function (args, callback) {
 exports.lookup = function (query, callback) {
 
   /**
-   * add 'l' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
+   * add 'lx' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
    */
-  var exeArgs = query.psargs || ['l'];
+  var exeArgs = query.psargs || ['lx'];
   var filter = {};
   var idList;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps-node",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A process lookup utility",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "sinon": "^2.1.0",
     "mocha": "^2.4.5"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -106,10 +106,13 @@ ps.kill( '12345', 'SIGKILL', function( err ) {
 });
 ```
 
-To be compatible with prior versions, you can use object as the second parameter:
+you can use object as the second parameter to pass more options:
 
 ```js
-ps.kill( '12345', { signal: 'SIGKILL' }, function(){});
+ps.kill( '12345', { 
+    signal: 'SIGKILL',
+    timeout: 10,  // will set up a ten seconds timeout if the killing is not successful
+}, function(){});
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ $ npm install ps-node
 
 This module uses different tools to get process list:
 
-- Linux / Mac: use `ps` command. Since the default result from shell command `$ ps` will not contain "command arguments" in linux like "ubuntu", ps-node add arguments `l` as default. Which means, the default value for option `psargs` is `l`.
+- Linux / Mac: use `ps` command. Since the default result from shell command `$ ps` will not contain "command arguments" in linux like "ubuntu", ps-node add arguments `lx` as default. Which means, the default value for option `psargs` is `lx`.
 - Win: use command `wmic process get ProcessId,CommandLine` through "cmd", more info about wmic is [here](https://social.technet.microsoft.com/Forums/windowsserver/en-US/ab6c7e6e-4ad4-4237-bab3-0349cd76c094/wmic-command-line-utilities?forum=winservercore). Anyway, there is also another tool name [tasklist](https://technet.microsoft.com/en-us/library/bb491010.aspx) in windows, which can also list all the running processes, but lack of command arguments infomation. But compared to wmic, I think this tool should have a higher performance. You should take a look at the wrapper for this tool [tasklist](https://github.com/sindresorhus/tasklist) by @sindresorhs if you are interested.
 
 ## Compatibility

--- a/test/node_process_for_test.js
+++ b/test/node_process_for_test.js
@@ -1,7 +1,10 @@
 var now = Date.now();
 console.log('[child] child process start!');
 
+function doSomething() {
+  return null;
+}
+
 setInterval(function () {
-  var interval = Date.now() - now;
-  console.log('[child] Timer finished, time consuming: ' + interval);
+  doSomething();
 }, 50);

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var PS = require('../index');
 var CP = require('child_process');
 var assert = require('assert');
 var Path = require('path');
-var IS_WIN = process.platform === 'win32';
+var Sinon = require('sinon');
 
 var serverPath = Path.resolve(__dirname, './node_process_for_test.js');
 var UpperCaseArg = '--UPPER_CASE';
@@ -18,6 +18,16 @@ function killProcess() {
   if (process.kill(pid, 0)) {
     process.kill(pid);
   }
+}
+
+var processKill = process.kill;
+
+function mockKill() {
+  process.kill = function() {};
+}
+
+function restoreKill() {
+  process.kill = processKill;
 }
 
 describe('test', function () {
@@ -97,10 +107,11 @@ describe('test', function () {
     });
   });
 
-  for (var i = 0; i < 20; i++) {
-    describe('#kill() test round: ' + i, function () {
+  describe('#kill()', function () {
 
-      it('kill', function (done) {
+    it('kill', function (done) {
+      PS.lookup({pid: pid}, function (err, list) {
+        assert.equal(list.length, 1);
         PS.kill(pid, function (err) {
           assert.equal(err, null);
           PS.lookup({pid: pid}, function (err, list) {
@@ -109,15 +120,20 @@ describe('test', function () {
           });
         });
       });
+    });
 
-      it('should not throw an exception if the callback is undefined', function (done) {
-        assert.doesNotThrow(function () {
-          PS.kill(pid);
-          setTimeout(done, 400);
+    it('should not throw an exception if the callback is undefined', function (done) {
+      assert.doesNotThrow(function () {
+        PS.kill(pid);
+        PS.kill(pid, function() {
+          done();
         });
       });
+    });
 
-      it('should force kill when opts.signal is SIGKILL', function (done) {
+    it('should force kill when opts.signal is SIGKILL', function (done) {
+      PS.lookup({pid: pid}, function (err, list) {
+        assert.equal(list.length, 1);
         PS.kill(pid, {signal: 'SIGKILL'}, function (err) {
           assert.equal(err, null);
           PS.lookup({pid: pid}, function (err, list) {
@@ -126,8 +142,11 @@ describe('test', function () {
           });
         });
       });
+    });
 
-      it('should throw error when opts.signal is invalid', function (done) {
+    it('should throw error when opts.signal is invalid', function (done) {
+      PS.lookup({pid: pid}, function (err, list) {
+        assert.equal(list.length, 1);
         PS.kill(pid, {signal: 'INVALID'}, function (err) {
           assert.notEqual(err, null);
           PS.kill(pid, function(){
@@ -136,5 +155,45 @@ describe('test', function () {
         });
       });
     });
-  }
+  });
+
+  describe('#kill() timeout: ', function () {
+    it('it should timeout after 30secs by default if the killing is not successful', function(done) {
+      mockKill();
+      var clock = Sinon.useFakeTimers();
+      var killStartDate = Date.now();
+      PS.lookup({pid: pid}, function (err, list) {
+        assert.equal(list.length, 1);
+        PS.kill(pid, function (err) {
+          assert.equal(Date.now() - killStartDate >= 30 * 1000, true);
+          assert.equal(err.message.indexOf('timeout') >= 0, true);
+          restoreKill();
+          PS.kill(pid, function(){
+            clock.restore();
+            done();
+          });
+        });
+        clock.tick(30 * 1000);
+      });
+    });
+
+    it('it should be able to set option to set the timeout', function(done) {
+      mockKill();
+      var clock = Sinon.useFakeTimers();
+      var killStartDate = Date.now();
+      PS.lookup({pid: pid}, function (err, list) {
+        assert.equal(list.length, 1);
+        PS.kill(pid, { timeout: 5 }, function (err) {
+          assert.equal(Date.now() - killStartDate >= 5 * 1000, true);
+          assert.equal(err.message.indexOf('timeout') >= 0, true);
+          restoreKill();
+          PS.kill(pid, function(){
+            clock.restore();
+            done();
+          });
+        });
+        clock.tick(5 * 1000);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# 0.1.6
---
- use `lx` as default options for `ps` command
- remove debugging console log for `kill()`
- add timeout for `kill()`, default to 30s