### PR TITLE
add ps options `lx` as default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,7 @@ var Exec = module.exports = exports = function (args, callback) {
  * @param {String|String[]} query.pid
  * @param {String} query.command RegExp String
  * @param {String} query.arguments RegExp String
+ * @param {String|array} query.psargs
  * @param {Function} callback
  * @param {Object=null} callback.err
  * @param {Object[]} callback.processList
@@ -115,9 +116,9 @@ var Exec = module.exports = exports = function (args, callback) {
 exports.lookup = function (query, callback) {
 
   /**
-   * add 'l' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
+   * add 'lx' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
    */
-  var exeArgs = query.psargs || ['l'];
+  var exeArgs = query.psargs || ['lx'];
   var filter = {};
   var idList;
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ $ npm install ps-node
 
 This module uses different tools to get process list:
 
-- Linux / Mac: use `ps` command. Since the default result from shell command `$ ps` will not contain "command arguments" in linux like "ubuntu", ps-node add arguments `l` as default. Which means, the default value for option `psargs` is `l`.
+- Linux / Mac: use `ps` command. Since the default result from shell command `$ ps` will not contain "command arguments" in linux like "ubuntu", ps-node add arguments `lx` as default. Which means, the default value for option `psargs` is `lx`.
 - Win: use command `wmic process get ProcessId,CommandLine` through "cmd", more info about wmic is [here](https://social.technet.microsoft.com/Forums/windowsserver/en-US/ab6c7e6e-4ad4-4237-bab3-0349cd76c094/wmic-command-line-utilities?forum=winservercore). Anyway, there is also another tool name [tasklist](https://technet.microsoft.com/en-us/library/bb491010.aspx) in windows, which can also list all the running processes, but lack of command arguments infomation. But compared to wmic, I think this tool should have a higher performance. You should take a look at the wrapper for this tool [tasklist](https://github.com/sindresorhus/tasklist) by @sindresorhs if you are interested.
 
 ## Compatibility


### PR DESCRIPTION
# What

Reported by https://github.com/neekey/ps/issues/47

According to `man ps` the `-x`:

>  -x      When displaying processes matched by other options, include processes which do not have a controlling terminal.  This is the opposite of the -X option.  If both -X and -x
             are specified in the same command, then ps will use the one which was specified last.

This will provide more processes to search.