### PR TITLE
add timeout support for `kill()`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -225,6 +225,7 @@ exports.kill = function( pid, signal, next ){
         clearTimeout(checkTimeoutTimer);
         finishCallback && finishCallback(err);
       } else if(list.length > 0) {
+        checkConfident = (checkConfident - 1) || 0;
         checkKilled(finishCallback);
       } else {
         checkConfident++;

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,7 @@ exports.lookup = function (query, callback) {
  * @param pid
  * @param {Object|String} signal
  * @param {String} signal.signal
+ * @param {number} signal.timeout
  * @param next
  */
 
@@ -199,6 +200,8 @@ exports.kill = function( pid, signal, next ){
     next = signal;
     signal = undefined;
   }
+
+  var checkTimeoutSeconds = (signal && signal.timeout) || 30;
 
   if (typeof signal === 'object') {
     signal = signal.signal;
@@ -211,27 +214,36 @@ exports.kill = function( pid, signal, next ){
   }
 
   var checkConfident = 0;
+  var checkTimeoutTimer = null;
+  var checkIsTimeout = false;
 
   function checkKilled(finishCallback) {
-    console.log('check kill success', pid, 'confident', checkConfident);
     exports.lookup({ pid: pid }, function(err, list) {
-      console.log('check kill success result:', (list || []).length);
+      if (checkIsTimeout) return;
+
       if (err) {
-          finishCallback && finishCallback(err);
-        } else if(list.length > 0) {
-          checkKilled(finishCallback);
+        clearTimeout(checkTimeoutTimer);
+        finishCallback && finishCallback(err);
+      } else if(list.length > 0) {
+        checkKilled(finishCallback);
+      } else {
+        checkConfident++;
+        if (checkConfident === 5) {
+          clearTimeout(checkTimeoutTimer);
+          finishCallback && finishCallback();
         } else {
-          checkConfident++;
-          if (checkConfident === 5) {
-            finishCallback && finishCallback();
-          } else {
-            checkKilled(finishCallback);
-          }
+          checkKilled(finishCallback);
         }
+      }
     });
   }
 
   next && checkKilled(next);
+
+  checkTimeoutTimer = next && setTimeout(function() {
+    checkIsTimeout = true;
+    next(new Error('Kill process timeout'));
+  }, checkTimeoutSeconds * 1000);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "sinon": "^2.1.0",
     "mocha": "^2.4.5"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -106,10 +106,13 @@ ps.kill( '12345', 'SIGKILL', function( err ) {
 });
 ```
 
-To be compatible with prior versions, you can use object as the second parameter:
+you can use object as the second parameter to pass more options:
 
 ```js
-ps.kill( '12345', { signal: 'SIGKILL' }, function(){});
+ps.kill( '12345', { 
+    signal: 'SIGKILL',
+    timeout: 10,  // will set up a ten seconds timeout if the killing is not successful
+}, function(){});
 
 ```
 

--- a/test/node_process_for_test.js
+++ b/test/node_process_for_test.js
@@ -1,7 +1,10 @@
 var now = Date.now();
 console.log('[child] child process start!');
 
+function doSomething() {
+  return null;
+}
+
 setInterval(function () {
-  var interval = Date.now() - now;
-  console.log('[child] Timer finished, time consuming: ' + interval);
+  doSomething();
 }, 50);

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var PS = require('../index');
 var CP = require('child_process');
 var assert = require('assert');
 var Path = require('path');
+var Sinon = require('sinon');
 
 var serverPath = Path.resolve(__dirname, './node_process_for_test.js');
 var UpperCaseArg = '--UPPER_CASE';
@@ -159,6 +160,7 @@ describe('test', function () {
   describe('#kill() timeout: ', function () {
     it('it should timeout after 30secs by default if the killing is not successful', function(done) {
       mockKill();
+      var clock = Sinon.useFakeTimers();
       var killStartDate = Date.now();
       PS.lookup({pid: pid}, function (err, list) {
         assert.equal(list.length, 1);
@@ -167,14 +169,17 @@ describe('test', function () {
           assert.equal(err.message.indexOf('timeout') >= 0, true);
           restoreKill();
           PS.kill(pid, function(){
+            clock.restore();
             done();
           });
         });
+        clock.tick(30 * 1000);
       });
     });
 
     it('it should be able to set option to set the timeout', function(done) {
       mockKill();
+      var clock = Sinon.useFakeTimers();
       var killStartDate = Date.now();
       PS.lookup({pid: pid}, function (err, list) {
         assert.equal(list.length, 1);
@@ -183,9 +188,11 @@ describe('test', function () {
           assert.equal(err.message.indexOf('timeout') >= 0, true);
           restoreKill();
           PS.kill(pid, function(){
+            clock.restore();
             done();
           });
         });
+        clock.tick(5 * 1000);
       });
     });
   });


### PR DESCRIPTION
# What

Add timeout for `kill()` function. Now by default the timeout will be 30s, if the killing is not successful after 30s, the callback will be invoked with an timeout error, you can also manually set a timeout value (as seconds):

```js
ps.kill(id, { timeout: 10 }, function(){}); // set the timeout to 10s
```