### PR TITLE
Fix empty callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ var Exec = module.exports = exports = function (args, callback) {
       }
     });
 
-    CMD.on('exit', function () {
+    CMD.on('close', function () {
 
       var beginRow;
       stdout = stdout.split(EOL);
@@ -89,7 +89,7 @@ var Exec = module.exports = exports = function (args, callback) {
       }
     });
 
-    child.on('exit', function () {
+    child.on('close', function () {
       if (stderr) {
         return callback(stderr.toString());
       }


### PR DESCRIPTION
Sometimes, the "exit" event is fired before the data has been received on stdout.
Using "close" event fix this issue