### PR TITLE
Drop node 0.12, and add Mac OS X to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
 - '6'
 - '5'
 - '4'
-- '0.12'
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 os:
-- linux
+  - osx
+  - linux
 language: node_js
 node_js:
-- '7'
-- '6'
-- '5'
-- '4'
+  - '7'
+  - '6'
+  - '5'
+  - '4'
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: "7"
     - nodejs_version: '6'
     - nodejs_version: '4'
-    - nodejs_version: '0.12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
Node 0.12 reached maintenance end of life in 12/2016.
https://github.com/nodejs/Release

Mac OS X has its own quirks in terms of `ps` output.