### PR TITLE
Pass PID list into wmic query to speed things up on Windows.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var SystemEOL = require('os').EOL;
  * @param {Object[]} callback.stdout
  */
 
-var Exec = module.exports = exports = function (args, callback) {
+var Exec = module.exports = exports = function (winArgs, args, callback) {
   var spawn = ChildProcess.spawn;
 
   // on windows, if use ChildProcess.exec(`wmic process get`), the stdout will gives you nothing
@@ -64,7 +64,7 @@ var Exec = module.exports = exports = function (args, callback) {
       callback(stderr, stdout.join(SystemEOL) || false);
     });
 
-    CMD.stdin.write('wmic process get ProcessId,ParentProcessId,CommandLine \n');
+    CMD.stdin.write('wmic process ' + winArgs.join(" ") + ' get ProcessId,ParentProcessId,CommandLine \n');
     CMD.stdin.end();
   }
   else {
@@ -119,6 +119,7 @@ exports.lookup = function (query, callback) {
    * add 'lx' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
    */
   var exeArgs = query.psargs || ['lx'];
+  var winArgs;
   var filter = {};
   var idList;
 
@@ -131,7 +132,7 @@ exports.lookup = function (query, callback) {
     else {
       idList = [query.pid];
     }
-
+	winArgs = ["where", '"' + idList.map(pid => "ProcessId="+pid).join(" OR ") + '"'];
     // Cast all PIDs as Strings
     idList = idList.map(function (v) {
       return String(v);
@@ -152,7 +153,7 @@ exports.lookup = function (query, callback) {
     filter['ppid'] = new RegExp(query.ppid);
   }
 
-  return Exec(exeArgs, function (err, output) {
+  return Exec(winArgs, exeArgs, function (err, output) {
     if (err) {
       return callback(err);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ exports.lookup = function (query, callback) {
    * add 'lx' as default ps arguments, since the default ps output in linux like "ubuntu", wont include command arguments
    */
   var exeArgs = query.psargs || ['lx'];
-  var winArgs;
+  var winArgs = [];
   var filter = {};
   var idList;
 


### PR DESCRIPTION
This is definitely a hack that only works when querying by PID, which is my use case.  It'll partially address #60 and #68.

It sped things up on Windows from 19 seconds to 0.25 seconds.  So it definitely works.  Surely, it would be great if someone takes this concept and fills it out to handle other use cases.